### PR TITLE
Calendar機能の追加

### DIFF
--- a/ruby/.vscode/launch.json
+++ b/ruby/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+  // IntelliSense を使用して利用可能な属性を学べます。
+  // 既存の属性の説明をホバーして表示します。
+  // 詳細情報は次を確認してください: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "rdbg",
+      "name": "Debug current file with rdbg",
+      "request": "launch",
+      "script": "${file}",
+      "args": [],
+      // "askParameters": true,
+      "useTerminal": true
+    }
+  ]
+}

--- a/ruby/calendar.rb
+++ b/ruby/calendar.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'optparse'
+require 'date'
+
+# オプション引数を有無に関わらず一旦代入
+month = ARGV.getopts('m:')['m']&.to_i
+
+# オプションあり、かつ範囲外の場合はエラー表示して終了
+if month && !(1..12).include?(month)
+  puts "#{month} is neither a month number (1..12) nor a name"
+  return
+end
+
+# 年月のデフォルトは月初。オプションが優先
+month ||= Date.today.month
+year = Date.today.year
+
+# Dateクラスから開始曜日、開始日、終了日を変数に代入
+start_date = Date.new(year, month, 1)
+start_day_of_week = start_date.wday # 日曜が0、土曜が6
+start_day_of_week = 7 if start_date.sunday? # 今後の処理のために日曜日を7として扱う
+start_day = start_date.day
+end_day = Date.new(year, month, -1).day
+
+# カレンダーのヘッダ部分の出力
+puts "      #{month}月  #{year}"
+puts ' 月 火 水 木 金 土 日'
+
+# 1日の開始曜日の調整：ずれる分だけ空白3つ出力
+print ' ' * 3 * (start_day_of_week - 1)
+
+# 1日から最終日までを出力
+(start_day..end_day).each do |day|
+  print format('% 3d', day)
+  puts "\n" if ((day + start_day_of_week - 1) % 7).zero?
+end
+
+# 整形用に改行
+puts "\n"

--- a/ruby/calendar.rb
+++ b/ruby/calendar.rb
@@ -13,13 +13,13 @@ if month && !(1..12).include?(month)
 end
 
 # 年月のデフォルトは月初。オプションが優先
-month ||= Date.today.month
-year = Date.today.year
+today = Date.today
+month ||= today.month
+year = today.year
 
 # Dateクラスから開始曜日、開始日、終了日を変数に代入
 start_date = Date.new(year, month, 1)
-start_day_of_week = start_date.wday # 日曜が0、土曜が6
-start_day_of_week = 7 if start_date.sunday? # 今後の処理のために日曜日を7として扱う
+start_day_of_week = start_date.sunday? ? 7 : start_date.wday # 日曜日を7として扱い、月〜土 = 1~6
 start_day = start_date.day
 end_day = Date.new(year, month, -1).day
 


### PR DESCRIPTION

## 課題のリンク

* https://github.com/happiness-chain/practice/blob/main/08_ruby/002_カレンダーを作る.md

## やったこと

* `$ ruby calendar.rb`で表示されるカレンダーを作成しました
  * optparseでオプション付き引数を扱いました
  * dateライブラリで開始日と終了日を取得してループでコンソール出力しました


## 動作確認方法

ターミナルで実行して目視確認しました

- 引数
  - なし
    - 今月のカレンダーが表示されること
    - ネット上のカレンダーと同一になっていること
  - -m 1..12(1日が全ての曜日をカバー)
    - ネット上のカレンダーと同一になっていること
  - -m 0,3
    - エラーメッセージが表示されてプログラムが終了すること
- 実行した一例は下記です

```sh
➜  ruby git:(calendar) ✗ ruby calendar.rb -m 10      
      10月  2023
 月 火 水 木 金 土 日
                    1
  2  3  4  5  6  7  8
  9 10 11 12 13 14 15
 16 17 18 19 20 21 22
 23 24 25 26 27 28 29
 30 31



➜  ruby git:(calendar) ✗ rubocop calendar.rb   
Inspecting 1 file
.

1 file inspected, no offenses detected

```

## その他

* 冗長に書いている気がします。厳しめにみてもらえると幸いです。
* 関連ブログ：https://qiita.com/takuzo8679/items/b18d8e403f328f40e8ac

